### PR TITLE
RFTools Main Config Balance Pass #1

### DIFF
--- a/config/rftools/main.cfg
+++ b/config/rftools/main.cfg
@@ -92,7 +92,7 @@ dimlets {
     D:afterCreationCostFactor=0.10000000149011612
 
     # Behaviour when sleeping in an RFTools dimension: 0 = do nothing, 1 = explode, 2 = set spawn
-    I:bedBehaviour=0
+    I:bedBehaviour=2
 
     # The height of the bedrock layer that is generated at the bottom of some world types. Set to 0 to disable this and get default bedrock generation
     I:bedrockLayer=1
@@ -314,7 +314,7 @@ environmental {
     I:environmentalMaxRF=500000
 
     # The minimum RF/tick usage that an active controller consumes
-    I:environmentalMinRFUsage=5
+    I:environmentalMinRFUsage=2500
 
     # RF per tick that the the environmental controller can receive
     I:environmentalRFPerTick=20000
@@ -341,16 +341,16 @@ environmental {
     D:peacefulRFPerTick=0.0010000000474974513
 
     # RF per tick/per block for the regeneration plus module
-    D:regenerationPlusRFPerTick=0.0044999998062849045
+    D:regenerationPlusRFPerTick=0.045
 
     # RF per tick/per block for the regeneration module
-    D:regenerationRFPerTick=0.001500000013038516
+    D:regenerationRFPerTick=0.015
 
     # RF per tick/per block for the saturation plus module
-    D:saturationPlusRFPerTick=0.003000000026077032
+    D:saturationPlusRFPerTick=0.03
 
     # RF per tick/per block for the saturation module
-    D:saturationRFPerTick=0.0010000000474974513
+    D:saturationRFPerTick=0.01
 
     # RF per tick/per block for the speed plus module
     D:speedPlusRFPerTick=0.003000000026077032
@@ -413,7 +413,7 @@ general {
     B:logging=false
 
     # The maximum amount of dimensional shards that can be infused in a single machine
-    I:maxInfuse=256
+    I:maxInfuse=0
 
     # The ID for the RFTools villager. -1 means disable, 0 means to automatically assigns an id, any other number will use that as fixed id
     I:villagerId=10
@@ -647,13 +647,13 @@ mobspawnamounts {
         I
         minecraft:experience_bottle
         0
-        0.1
+        100.0
      >
     S:Dragon.spawnamount.1 <
         B
         minecraft:end_stone
         0
-        200.0
+        2000000.0
      >
     S:Dragon.spawnamount.2 <
         L
@@ -719,7 +719,7 @@ mobspawnamounts {
         I
         minecraft:iron_ingot
         0
-        0.1
+        10.0
      >
     S:"Iron Golem.spawnamount.1" <
         B
@@ -971,7 +971,7 @@ mobspawnamounts {
         I
         minecraft:nether_star
         0
-        0.1
+        1.0
      >
     S:Wither.spawnamount.1 <
         B


### PR DESCRIPTION
* Allow players to set spawn in RFTools dims.
* Add baseline 2500 RF/t requirement for the Environmental Controller (before modules)
* Increase power requirements for Regen and Saturation EnvCon modules by 10x.
* Decrease max machine infusion to 0. (Prevents reducing power costs.)
* Spawner Tweaks: Wither requires a full nether star to summon another one. Iron Golem takes 10 iron bars. Ender Dragon takes 2 million endstone and 100 XP Bottles (Couldn't find a way to disable this outright. Plus we have two other ways to respawn the Dragon already.)