### PR TITLE
Disable Hunger Overhaul Low Health Regen Penalty

### DIFF
--- a/config/HungerOverhaul/HungerOverhaul.cfg
+++ b/config/HungerOverhaul/HungerOverhaul.cfg
@@ -254,7 +254,7 @@ health {
     I:minHungerToHeal=7
 
     # The lower your health the longer it takes to regen [vanilla: false] [default: true]
-    B:modifyRegenRateOnLowHealth=true
+    B:modifyRegenRateOnLowHealth=false
 }
 
 


### PR DESCRIPTION
Overly penalizing when combined with ticon extra hearts as it is % based.