### PR TITLE
Cyberware upgrade modifications.

### DIFF
--- a/config/cyberware.cfg
+++ b/config/cyberware.cfg
@@ -86,10 +86,10 @@ machines {
     S:"Additive chance for Scanner per extra item"=10.0
 
     #  [range: 0.0 ~ 100.0, default: 15.0]
-    S:"Chance of blueprint from Engineering Table"=15.0
+    S:"Chance of blueprint from Engineering Table"=20.0
 
     #  [range: 0.0 ~ 100.0, default: 10.0]
-    S:"Chance of blueprint from Scanner"=10.0
+    S:"Chance of blueprint from Scanner"=15.0
 
     # 24000 is one Minecraft day, 1200 is one real-life minute [range: 0 ~ 2147483647, default: 24000]
     I:"Ticks taken per Scanner operation"=24000
@@ -101,22 +101,22 @@ mobs {
     B:"Disable cyberzombies"=false
 
     # Vanilla Zombie = 4, Enderman = 4, Witch = 1 [range: 0 ~ 2147483647, default: 1]
-    I:"Maximum Cyberzombie pack size"=1
+    I:"Maximum Cyberzombie pack size"=6
 
     # Vanilla Zombie = 4, Enderman = 1, Witch = 1 [range: 0 ~ 2147483647, default: 1]
-    I:"Minimum Cyberzombie pack size"=1
+    I:"Minimum Cyberzombie pack size"=3
 
     #  [range: 0.0 ~ 100.0, default: 50.0]
-    S:"Percent chance a Cyberzombie drops an item"=50.0
+    S:"Percent chance a Cyberzombie drops an item"=25.0
 
     # Vanilla Zombie = 100, Enderman = 10, Witch = 5 [range: 0 ~ 2147483647, default: 15]
-    I:"Spawning weight of Cyberzombies"=15
+    I:"Spawning weight of Cyberzombies"=25
 }
 
 
 other {
     #  [default: true]
-    B:"Enable Katana"=true
+    B:"Enable Katana"=false
 
     #  [default: true]
     B:"Enable Trenchcoat, Mirrorshades, and Biker Jacket"=true

--- a/config/cyberware.cfg
+++ b/config/cyberware.cfg
@@ -74,7 +74,7 @@ essence {
 
 gamerules {
     # Determines if players drop their Cyberware on death. Does not change settings on existing worlds, use /gamerule for that. Overridden if cyberware_keepCyberware is true [default: false]
-    B:"Default for gamerule cyberware_dropCyberware"=false
+    B:"Default for gamerule cyberware_dropCyberware"=true
 
     # Determines if players keep their Cyberware between lives. Does not change settings on existing worlds, use /gamerule for that. [default: false]
     B:"Default for gamerule cyberware_keepCyberware"=false

--- a/config/cyberware.cfg
+++ b/config/cyberware.cfg
@@ -83,13 +83,13 @@ gamerules {
 
 machines {
     #  [range: 0.0 ~ 100.0, default: 10.0]
-    S:"Additive chance for Scanner per extra item"=10.0
+    S:"Additive chance for Scanner per extra item"=0.0
 
     #  [range: 0.0 ~ 100.0, default: 15.0]
-    S:"Chance of blueprint from Engineering Table"=20.0
+    S:"Chance of blueprint from Engineering Table"=50.0
 
     #  [range: 0.0 ~ 100.0, default: 10.0]
-    S:"Chance of blueprint from Scanner"=15.0
+    S:"Chance of blueprint from Scanner"=0.0
 
     # 24000 is one Minecraft day, 1200 is one real-life minute [range: 0 ~ 2147483647, default: 24000]
     I:"Ticks taken per Scanner operation"=24000
@@ -104,10 +104,10 @@ mobs {
     I:"Maximum Cyberzombie pack size"=6
 
     # Vanilla Zombie = 4, Enderman = 1, Witch = 1 [range: 0 ~ 2147483647, default: 1]
-    I:"Minimum Cyberzombie pack size"=3
+    I:"Minimum Cyberzombie pack size"=4
 
     #  [range: 0.0 ~ 100.0, default: 50.0]
-    S:"Percent chance a Cyberzombie drops an item"=25.0
+    S:"Percent chance a Cyberzombie drops an item"=0.0
 
     # Vanilla Zombie = 100, Enderman = 10, Witch = 5 [range: 0 ~ 2147483647, default: 15]
     I:"Spawning weight of Cyberzombies"=25
@@ -125,7 +125,7 @@ other {
     B:"Enable crafting recipe for Robosurgeon"=false
 
     #  [range: 0 ~ 2147483647, default: 1]
-    I:"RF/Tesla per internal power unit"=1
+    I:"RF/Tesla per internal power unit"=5
 }
 
 

--- a/config/cyberware.cfg
+++ b/config/cyberware.cfg
@@ -65,10 +65,10 @@ defaults {
 
 essence {
     #  [range: 0 ~ 2147483647, default: 25]
-    I:"Critical Essence value, where rejection begins"=25
+    I:"Critical Essence value, where rejection begins"=0
 
     #  [range: 0 ~ 2147483647, default: 100]
-    I:"Maximum Essence"=100
+    I:"Maximum Essence"=250
 }
 
 


### PR DESCRIPTION
Alters the way you get cyberware upgrades by restricting gain methods to crafting/exploring, while allowing you to use more upgrades. This makes CyberWare mod a bit more end-game material. Also disabled katana because slashblade. (#135)