### PR TITLE
correct data types in HungerOverhaul.cfg

### DIFF
--- a/config/HungerOverhaul/HungerOverhaul.cfg
+++ b/config/HungerOverhaul/HungerOverhaul.cfg
@@ -221,37 +221,37 @@ harvesting {
     B:enableRightClickHarvesting=true
 
     # Reduces the amount of growth from a successful bonemeal on certain plants (uses IguanaMan's opinionated values) [vanilla: false] [default: true]
-    S:modifyBonemealGrowth=true
+    B:modifyBonemealGrowth=true
 
     # Enables/disables modification of the item drops of crops when breaking them (produce and seeds) [vanilla: false] [default: true]
-    S:modifyCropDropsBreak=false
+    B:modifyCropDropsBreak=false
 
     # Enables/disables modification of the item drops of crops when right clicking them (produce and seeds) [vanilla: false] [default: true]
-    S:modifyCropDropsRightClick=false
+    B:modifyCropDropsRightClick=false
 
     # Maximum number of produce you get when harvesting a non-tree crop by breaking it (modifyCropDrops must be true) [vanilla: 4] [range: 0 ~ 2147483647, default: 4]
-    S:producePerHarvestBreakMax=4
+    I:producePerHarvestBreakMax=4
 
     # Minimum number of produce you get when harvesting a non-tree crop by breaking it (modifyCropDrops must be true) [vanilla: 2] [range: 0 ~ 2147483647, default: 2]
-    S:producePerHarvestBreakMin=2
+    I:producePerHarvestBreakMin=2
 
     # Maximum number of produce you get when harvesting a non-tree crop with right click (modifyCropDrops must be true) [vanilla: 4] [range: 0 ~ 2147483647, default: 4]
-    S:producePerHarvestRightClickMax=4
+    I:producePerHarvestRightClickMax=4
 
     # Minimum number of produce you get when harvesting a non-tree crop with right click (modifyCropDrops must be true) [vanilla: 2] [range: 0 ~ 2147483647, default: 2]
-    S:producePerHarvestRightClickMin=2
+    I:producePerHarvestRightClickMin=2
 
     # Maximum number of seeds you get when harvesting a non-tree crop by breaking it (modifyCropDrops must be tree) [vanilla: 0] [range: 0 ~ 2147483647, default: 0]
-    S:seedsPerHarvestBreakMax=0
+    I:seedsPerHarvestBreakMax=0
 
     # Minimum number of seeds you get when harvesting a non-tree crop by breaking it (modifyCropDrops must be true) [vanilla: 0] [range: 0 ~ 2147483647, default: 0]
-    S:seedsPerHarvestBreakMin=0
+    I:seedsPerHarvestBreakMin=0
 
     # Maximum number of seeds you get when harvesting a non-tree crop with right click (modifyCropDrops must be true) [vanilla: 0] [range: 0 ~ 2147483647, default: 0]
-    S:seedsPerHarvestRightClickMax=0
+    I:seedsPerHarvestRightClickMax=0
 
     # Minimum number of seeds you get when harvesting a non-tree crop with right click (modifyCropDrops must be true) [vanilla: 0] [range: 0 ~ 2147483647, default: 0]
-    S:seedsPerHarvestRightClickMin=0
+    I:seedsPerHarvestRightClickMin=0
 }
 
 


### PR DESCRIPTION
When I was auditing the differences between the default Hunger Overhaul config and the current one, I noticed the data types of these config variables was different than in the defaults. (and the one in the defaults were more appropriately specific).

Dunno how the parser for this file works, or if it actually cares. (It seems like a weird thing to have as syntax in the config file and not in the code object it would load it in to.)