### PR TITLE
Weapon damage values

### DIFF
--- a/config/ImmersiveEngineering.cfg
+++ b/config/ImmersiveEngineering.cfg
@@ -430,10 +430,10 @@ tools {
      >
 
     # The base amount of RF consumed per shot by the Railgun
-    I:"Railgun: Consumed"=1600
+    I:"Railgun: Consumed"=800
 
     # When something is hurt by a railgun, the default damage for the used projectile is multiplied by this value
-    D:"Railgun: Damage multiplier"=1.0
+    D:"Railgun: Damage multiplier"=1.8
 }
 
 


### PR DESCRIPTION
Looks like the 1.7.10 version was default at what we modified the 1.10 version to, excepting the railgun values. So that's the only thing updated here.