### PR TITLE
Allows mob heads to be harvested with OC robots

### DIFF
--- a/config/IguanaTinkerTweaks/Modules.cfg
+++ b/config/IguanaTinkerTweaks/Modules.cfg
@@ -11,7 +11,7 @@
     B:Items=true
 
     # Adds additional MobHeads and control over MobHead drops.
-    B:MobHeads=true
+    B:MobHeads=false
 
     # Makes Saw cut stuff again
     B:MultipartCompat=true


### PR DESCRIPTION
Bug that prevents mobheads from being harvested from OC robot, example -  witherheads, autonomous activator might also be effected